### PR TITLE
Prepare for release v2020.09.04-beta.0

### DIFF
--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2020.07.10-beta.0
-appVersion: v2020.07.10-beta.0
+version: v2020.09.04-beta.0
+appVersion: v2020.09.04-beta.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -51,7 +51,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.14.0-beta.1
+      - version: v0.14.0-beta.2
   - chart:
       features:
       - KubeDB Catalog by AppsCode - Catalog for database versions
@@ -59,7 +59,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.14.0-beta.1
+      - version: v0.14.0-beta.2
   - chart:
       features:
       - A Helm chart for cert-manager

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2020.07.10-beta.0
-appVersion: v2020.07.10-beta.0
+version: v2020.09.04-beta.0
+appVersion: v2020.09.04-beta.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -54,7 +54,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.14.0-beta.1
+      - version: v0.14.0-beta.2
   - chart:
       features:
       - KubeDB by AppsCode - Production ready databases on Kubernetes
@@ -70,7 +70,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.14.0-beta.1
+      - version: v0.14.0-beta.2
   - chart:
       features:
       - A Helm chart for cert-manager


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.09.04-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/5
Signed-off-by: 1gtm <1gtm@appscode.com>