### PR TITLE
Prepare for release v2021.01.14

### DIFF
--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2021.01.02-rc.0
-appVersion: v2021.01.02-rc.0
+version: v2021.01.14
+appVersion: v2021.01.14
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -51,7 +51,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.16.0-rc.0
+      - version: v0.16.0
   - chart:
       features:
       - KubeDB Catalog by AppsCode - Catalog for database versions
@@ -59,7 +59,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.16.0-rc.0
+      - version: v0.16.0
   - chart:
       features:
       - A Helm chart for cert-manager

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2021.01.02-rc.0
-appVersion: v2021.01.02-rc.0
+version: v2021.01.14
+appVersion: v2021.01.14
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -54,7 +54,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.16.0-rc.0
+      - version: v0.16.0
   - chart:
       features:
       - KubeDB by AppsCode - Production ready databases on Kubernetes
@@ -62,14 +62,14 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.3.0-rc.0
+      - version: v0.3.0
   - chart:
       features:
       - KubeDB by AppsCode - Production ready databases on Kubernetes
       name: kubedb-autoscaler
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.1.0-rc.0
+      - version: v0.1.0
   - chart:
       features:
       - KubeDB Catalog by AppsCode - Catalog for database versions
@@ -77,7 +77,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.16.0-rc.0
+      - version: v0.16.0
   - chart:
       features:
       - A Helm chart for cert-manager


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.14
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>