### PR TITLE
Prepare for release v2022.10.12-rc.0

### DIFF
--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2022.08.08
-appVersion: v2022.08.08
+version: v2022.10.12-rc.0
+appVersion: v2022.10.12-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -7,65 +7,65 @@ spec:
   description: Free open source edition for test and development
   displayName: Kubedb Community
   features:
-    - trait: Recommended for
-      value: Recommended if you are experimenting or testing
-    - trait: Response Times
-      value: Best effort
-    - trait: Support Coverage
-      value: N/A
-    - trait: Emergency patches
-      value: x
-    - trait: Unlimited Incidents
-      value: x
-    - trait: Contacts for Ticketing
-      value: x
-    - trait: Community Support
-      value: Included (Public Slack & GitHub issues)
-    - trait: Remote Hands (Debug via Zoom)
-      value: Yes (charged at $200/hr)
-    - trait: Production Runbook
-      value: x
-    - trait: Dedicated Private chat (via Slack)
-      value: x
-    - trait: Phone support
-      value: x
-    - trait: Architectural Guidance
-      value: x
-    - trait: Professional Services
-      value: Additional fees
+  - trait: Recommended for
+    value: Recommended if you are experimenting or testing
+  - trait: Response Times
+    value: Best effort
+  - trait: Support Coverage
+    value: N/A
+  - trait: Emergency patches
+    value: x
+  - trait: Unlimited Incidents
+    value: x
+  - trait: Contacts for Ticketing
+    value: x
+  - trait: Community Support
+    value: Included (Public Slack & GitHub issues)
+  - trait: Remote Hands (Debug via Zoom)
+    value: Yes (charged at $200/hr)
+  - trait: Production Runbook
+    value: x
+  - trait: Dedicated Private chat (via Slack)
+    value: x
+  - trait: Phone support
+    value: x
+  - trait: Architectural Guidance
+    value: x
+  - trait: Professional Services
+    value: Additional fees
   icons:
-    - src: 'https://cdn.appscode.com/images/icon/kubedb.png'
-      type: image/png
+  - src: https://cdn.appscode.com/images/icon/kubedb.png
+    type: image/png
   links:
-    - description: website
-      url: 'https://github.com/kubedb/installer'
+  - description: website
+    url: https://github.com/kubedb/installer
   maintainers:
-    - email: kubedb@appscode.com
-      name: appscode
+  - email: kubedb@appscode.com
+    name: appscode
   namespace: kube-system
   packages:
-    - chart:
-        features:
-          - KubeDB by AppsCode - Production ready databases on Kubernetes
-        name: kubedb
-        required: true
-        url: 'https://charts.appscode.com/stable/'
-        versions:
-          - version: v2022.08.08
-    - chart:
-        features:
-          - A Helm chart for cert-manager
-        name: cert-manager
-        namespace: cert-manager
-        url: 'https://charts.jetstack.io'
-        versions:
-          - version: v1.9.1
-    - chart:
-        features:
-          - Stash by AppsCode - Backup your Kubernetes native applications
-        name: stash
-        required: true
-        url: 'https://charts.appscode.com/stable/'
-        versions:
-          - version: v2022.07.09
+  - chart:
+      features:
+      - KubeDB by AppsCode - Production ready databases on Kubernetes
+      name: kubedb
+      required: true
+      url: https://charts.appscode.com/stable/
+      versions:
+      - version: v2022.10.12-rc.0
+  - chart:
+      features:
+      - A Helm chart for cert-manager
+      name: cert-manager
+      namespace: cert-manager
+      url: https://charts.jetstack.io
+      versions:
+      - version: v1.9.1
+  - chart:
+      features:
+      - Stash by AppsCode - Backup your Kubernetes native applications
+      name: stash
+      required: true
+      url: https://charts.appscode.com/stable/
+      versions:
+      - version: v2022.07.09
 status: {}

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2022.08.08
-appVersion: v2022.08.08
+version: v2022.10.12-rc.0
+appVersion: v2022.10.12-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -54,7 +54,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v2022.08.08
+      - version: v2022.10.12-rc.0
   - chart:
       features:
       - A Helm chart for cert-manager


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.10.12-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/57
Signed-off-by: 1gtm <1gtm@appscode.com>