### PR TITLE
Prepare for release v2023.06.13-rc.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,12 @@ on:
   push:
     branches:
       - master
-
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -69,7 +70,7 @@ jobs:
           echo
           kubectl version
           echo
-          kubectl apply -f https://github.com/kubepack/kubepack/raw/master/crds/kubepack.com_bundles.yaml --validate=false
+          kubectl apply -f https://github.com/kubepack/kubepack/raw/v0.5.2/crds/kubepack.com_bundles.yaml --validate=false
           kubectl wait --for=condition=NamesAccepted crds --all --timeout=5m
 
       - name: Test bundles

--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -51,7 +51,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v2023.04.10
+      - version: v2023.06.13-rc.0
   - chart:
       features:
       - A Helm chart for cert-manager

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -54,7 +54,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v2023.04.10
+      - version: v2023.06.13-rc.0
   - chart:
       features:
       - A Helm chart for cert-manager


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.06.13-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/70
Signed-off-by: 1gtm <1gtm@appscode.com>