### PR TITLE
Prepare for release v2024.1.7-beta.0

### DIFF
--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2023.12.28
-appVersion: v2023.12.28
+version: v2024.1.7-beta.0
+appVersion: v2024.1.7-beta.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -49,15 +49,17 @@ spec:
       - KubeDB by AppsCode - Production ready databases on Kubernetes
       name: kubedb
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
-      - version: v2023.12.28
+      - version: v2024.1.7-beta.0
   - chart:
       features:
       - A Helm chart for cert-manager
       name: cert-manager
       namespace: cert-manager
-      url: https://charts.jetstack.io
+      sourceRef:
+        name: ""
       versions:
       - version: v1.9.1
   - chart:
@@ -65,7 +67,8 @@ spec:
       - Stash by AppsCode - Backup your Kubernetes native applications
       name: stash
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
       - version: v2022.07.09
 status: {}

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2023.12.28
-appVersion: v2023.12.28
+version: v2024.1.7-beta.0
+appVersion: v2024.1.7-beta.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -52,16 +52,18 @@ spec:
       - KubeDB by AppsCode - Production ready databases on Kubernetes
       name: kubedb
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
-      - version: v2023.12.28
+      - version: v2024.1.7-beta.0
   - chart:
       features:
       - A Helm chart for cert-manager
       name: cert-manager
       namespace: cert-manager
       required: true
-      url: https://charts.jetstack.io
+      sourceRef:
+        name: ""
       versions:
       - version: v1.9.1
   - chart:
@@ -69,7 +71,8 @@ spec:
       - Stash by AppsCode - Backup your Kubernetes native applications
       name: stash
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
       - version: v2022.07.09
 status: {}


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.7-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/80
Signed-off-by: 1gtm <1gtm@appscode.com>