### PR TITLE
Prepare for release v2024.3.9-rc.0

### DIFF
--- a/charts/kubedb-community/Chart.yaml
+++ b/charts/kubedb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-community
 description: KubeDB Community Plan
 type: application
-version: v2024.2.14
-appVersion: v2024.2.14
+version: v2024.3.9-rc.0
+appVersion: v2024.3.9-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-community/templates/bundle.yaml
+++ b/charts/kubedb-community/templates/bundle.yaml
@@ -52,7 +52,7 @@ spec:
       sourceRef:
         name: ""
       versions:
-      - version: v2024.2.14
+      - version: v2024.3.9-rc.0
   - chart:
       features:
       - A Helm chart for cert-manager

--- a/charts/kubedb-enterprise/Chart.yaml
+++ b/charts/kubedb-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-enterprise
 description: KubeDB Enterprise Plan
 type: application
-version: v2024.2.14
-appVersion: v2024.2.14
+version: v2024.3.9-rc.0
+appVersion: v2024.3.9-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-enterprise/templates/bundle.yaml
+++ b/charts/kubedb-enterprise/templates/bundle.yaml
@@ -55,7 +55,7 @@ spec:
       sourceRef:
         name: ""
       versions:
-      - version: v2024.2.14
+      - version: v2024.3.9-rc.0
   - chart:
       features:
       - A Helm chart for cert-manager


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.3.9-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/86
Signed-off-by: 1gtm <1gtm@appscode.com>